### PR TITLE
Generating secret salt and cipherSeed in template

### DIFF
--- a/.sti/bin/assemble
+++ b/.sti/bin/assemble
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-/usr/local/sti/assemble
+source /usr/local/sti/assemble
 
 [[ -d ./app/tmp ]] && chmod -R go+rw ./app/tmp
 

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -25,8 +25,8 @@ include(dirname(dirname(dirname(__FILE__))) . DS . 'lib' . DS . 'openshift.php')
 
 // Set the default keys to use
 $_default_keys = array(
-    'Security.salt'       => 'Er2G93bfqyffIxf3r2TVoUuREwv4iR2GweWg349m1',
-    'Security.cipherSeed' => '244654350562786442415254364540'
+    'Security.salt'       => getenv("CAKEPHP_SECURITY_SALT"),
+    'Security.cipherSeed' => getenv("CAKEPHP_SECURITY_CIPHER_SEED")
 );
 
 // This function gets called by openshift_secure and passes an array

--- a/lib/openshift.php
+++ b/lib/openshift.php
@@ -9,11 +9,11 @@
 //    'original' => original value
 //  }
 function openshift_secure($default_keys,$secure_function = null) {
-  // Attempts to get secret token from CAKEPHP_SECRET_KEY,
+  // Attempts to get secret token from CAKEPHP_SECRET_TOKEN,
   // generated in openshift template in openshift/templates.
   // For development purposes a default secret token is used.
-  if ( getenv('CAKEPHP_SECRET_KEY') != '' ) {
-    $my_token = getenv('CAKEPHP_SECRET_KEY');
+  if ( getenv('CAKEPHP_SECRET_TOKEN') != '' ) {
+    $my_token = getenv('CAKEPHP_SECRET_TOKEN');
   } else {
     $my_token = 'te5t5tr1ng4l0c4ld3v3l0pm3nt';
   }

--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -191,8 +191,16 @@
                     "value": "${DATABASE_PASSWORD}"
                   },
                   {
-                    "name": "CAKEPHP_SECRET_KEY",
-                    "value": "${CAKEPHP_SECRET_KEY}"
+                    "name": "CAKEPHP_SECRET_TOKEN",
+                    "value": "${CAKEPHP_SECRET_TOKEN}"
+                  },
+                  {
+                    "name": "CAKEPHP_SECURITY_SALT",
+                    "value": "${CAKEPHP_SECURITY_SALT}"
+                  },
+                  {
+                    "name": "CAKEPHP_SECURITY_CIPHER_SEED",
+                    "value": "${CAKEPHP_SECURITY_CIPHER_SEED}"
                   }
                 ]
               }
@@ -335,10 +343,22 @@
       "from": "[a-zA-Z0-9]{16}"
     },
     {
-      "name": "CAKEPHP_SECRET_KEY",
+      "name": "CAKEPHP_SECRET_TOKEN",
       "description": "Set this to a long random string",
       "generate": "expression",
       "from": "[\\w]{50}"
+    },
+    {
+      "name": "CAKEPHP_SECURITY_SALT",
+      "description": "Security salt for session hash",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{40}"
+    },
+    {
+      "name": "CAKEPHP_SECURITY_CIPHER_SEED",
+      "description": "Security cipher seed for session hash",
+      "generate": "expression",
+      "from": "[0-9]{30}"
     }
   ]
 }

--- a/openshift/templates/cakephp.json
+++ b/openshift/templates/cakephp.json
@@ -180,8 +180,16 @@
                     "value": "${DATABASE_PASSWORD}"
                   },
                   {
-                    "name": "CAKEPHP_SECRET_KEY",
-                    "value": "${CAKEPHP_SECRET_KEY}"
+                    "name": "CAKEPHP_SECRET_TOKEN",
+                    "value": "${CAKEPHP_SECRET_TOKEN}"
+                  },
+                  {
+                    "name": "CAKEPHP_SECURITY_SALT",
+                    "value": "${CAKEPHP_SECURITY_SALT}"
+                  },
+                  {
+                    "name": "CAKEPHP_SECURITY_CIPHER_SEED",
+                    "value": "${CAKEPHP_SECURITY_CIPHER_SEED}"
                   }
                 ]
               }
@@ -237,10 +245,22 @@
       "description": "Database user password"
     },
     {
-      "name": "CAKEPHP_SECRET_KEY",
+      "name": "CAKEPHP_SECRET_TOKEN",
       "description": "Set this to a long random string",
       "generate": "expression",
       "from": "[\\w]{50}"
+    },
+    {
+      "name": "CAKEPHP_SECURITY_SALT",
+      "description": "Security salt for session hash",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{40}"
+    },
+    {
+      "name": "CAKEPHP_SECURITY_CIPHER_SEED",
+      "description": "Security cipher seed for session hash",
+      "generate": "expression",
+      "from": "[0-9]{30}"
     }
   ]
 }


### PR DESCRIPTION
Generating the salt and cipherSeed for the sessions in the template so the user doesn't have to change it manually.
@bparees PTAL, would like to merge this before https://github.com/openshift/cakephp-ex/pull/6 , so we can incorporate these envars and their purpose into README maybe in the welcome page (if necessary)