### PR TITLE
correct database env var names

### DIFF
--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -262,11 +262,10 @@ $ git push</pre>
 
 <pre>
 oc env dc/cakephp-mysql-example DATABASE_SERVICE_NAME=&lt;database service name&gt;
-oc env dc/cakephp-mysql-example &lt;DATABASE_SERVICE_NAME&gt;_SERVICE_HOST=&lt;database service ip&gt;
-oc env dc/cakephp-mysql-example &lt;DATABASE_SERVICE_NAME&gt;_SERVICE_PORT=&lt;database service port&gt;
-oc env dc/cakephp-mysql-example MYSQL_DATABASE=&lt;your created database&gt;
-oc env dc/cakephp-mysql-example MYSQL_USER=&lt;your database user&gt;
-oc env dc/cakephp-mysql-example MYSQL_PASSWORD=&lt;your database user's password&gt;
+oc env dc/cakephp-mysql-example DATABASE_ENGINE=mysql
+oc env dc/cakephp-mysql-example DATABASE_NAME=&lt;your created database&gt;
+oc env dc/cakephp-mysql-example DATABASE_USER=&lt;your database user&gt;
+oc env dc/cakephp-mysql-example DATABASE_PASSWORD=&lt;your database user's password&gt;
 </pre>
                   </p>
                   <p>


### PR DESCRIPTION
Correct the env vars to match those actually used by the DeploymentConfig

```
$ oc env dc cakephp-mysql-example --list
# deploymentconfigs cakephp-mysql-example, container cakephp-mysql-example
DATABASE_SERVICE_NAME=mysql
DATABASE_ENGINE=mysql
DATABASE_NAME=default
DATABASE_USER=cakephp
DATABASE_PASSWORD=nosecret
```
