### PR TITLE
get as close to no value as currently possible

### DIFF
--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -166,7 +166,7 @@
             "containers": [
               {
                 "name": "cakephp-mysql-example",
-                "image": "SET_BY_TRIGGER",
+                "image": " ",
                 "ports": [
                   {
                     "containerPort": 8080
@@ -312,7 +312,7 @@
             "containers": [
               {
                 "name": "mysql",
-                "image": "SET_BY_TRIGGER",
+                "image": " ",
                 "ports": [
                   {
                     "containerPort": 3306

--- a/openshift/templates/cakephp.json
+++ b/openshift/templates/cakephp.json
@@ -155,7 +155,7 @@
             "containers": [
               {
                 "name": "cakephp-example",
-                "image": "SET_BY_TRIGGER",
+                "image": " ",
                 "ports": [
                   {
                     "containerPort": 8080


### PR DESCRIPTION
@bparees @smarterclayton @jwforres @kargakis - moving the #aos discussion here

So k8s validation prevents an empty string for the container's image field:  https://github.com/openshift/origin/blob/master/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go#L1311-L1313

Putting in a single space works the same as putting in SET_BY_TRIGGER or cakephp-mysql-example (the value prior to SET_BY_TRIGGER), and we avoid the race condition with the image change trigger coming in too late and the value in the image field resulting in an incorrect image getting pulled in (if that field has a valid image name in it).

Any chance we can live with " " in the interim (and continue debugging the images extended tests), or do we want to gate any further change with changing the k8s validation to allow empty strings? 