### PR TITLE
Switch from ubuntu-20.04 -> ubuntu-lastest

### DIFF
--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -5,8 +5,8 @@ on:
 jobs:
   openshift-tests:
     # This job only runs for '[test] pull request comments by owner, member
-    name: "RHEL8 tests: imagestream ${{ matrix.version }}"
-    runs-on: ubuntu-20.04
+    name: "RHEL9 tests: imagestream ${{ matrix.version }}"
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -20,11 +20,11 @@ jobs:
       - uses: sclorg/testing-farm-as-github-action@main
         with:
           api_key: ${{ secrets.TF_INTERNAL_API_KEY }}
-          compose: "RHEL-8.8.0-Nightly"
+          compose: "RHEL-9.4.0-Nightly"
           git_url: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
           git_ref: "master"
           tf_scope: "private"
-          tmt_plan_regex: "rhel8-openshift-4"
+          tmt_plan_regex: "rhel9-openshift-4"
           update_pull_request_status: true
-          pull_request_status_name: "RHEL8-OpenShift-4 - imagestream test ${{ matrix.version }}"
+          pull_request_status_name: "RHEL9-OpenShift-4 - imagestream test ${{ matrix.version }}"
           variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};OS=rhel8;SINGLE_VERSION=${{ matrix.version }};TEST_NAME=test-openshift-4"


### PR DESCRIPTION
Ubuntu-20.04 was retired in March 2025 and therefore GitHub Actions are not executed at all


