### PR TITLE
Fix test suite for testing PHP application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-.PHONY: test-openshift-4
-test-openshift-4:
-	cd tests && PYTHONPATH=$(CURDIR) python3 -m pytest --verbose --color=yes --showlocals .
+.PHONY: test-openshift-pytest
+test-openshift-pytest:
+	cd tests && PYTHONPATH=$(CURDIR) python3.12 -m pytest -s -rA --showlocals -vv test_*.py

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: test-openshift-pytest
 test-openshift-pytest:
-	cd tests && PYTHONPATH=$(CURDIR) python3.12 -m pytest -s -rA --showlocals -vv test_*.py
+	cd tests && PYTHONPATH=$(CURDIR) python3.12 -m pytest -s -rA --showlocals -vv test_cakephp.py

--- a/tests/test_cakephp.py
+++ b/tests/test_cakephp.py
@@ -18,7 +18,7 @@ class TestCakePHPAppExTemplate:
 		self.oc_api = OpenShiftAPI(pod_name_prefix="cakephp-example")
 		json_raw_file = self.oc_api.get_raw_url_for_json(container="s2i-php-container", dir="imagestreams",
 														 filename="php-rhel.json")
-		self.oc_api.import_is(path=json_raw_file, name="php")
+		self.oc_api.import_is(path=json_raw_file, name="php", skip_check=True)
 
 	def teardown_method(self):
 		self.oc_api.delete_project()
@@ -29,7 +29,7 @@ class TestCakePHPAppExTemplate:
 		if VERSION.startswith("7.4") or VERSION.startswith("8.0"):
 			branch_to_test = "4.X"
 			expected_output = "Welcome to CakePHP 4"
-		if VERSION.startswith("8.1") or VERSION.startswith("8.2"):
+		if VERSION.startswith("8.1") or VERSION.startswith("8.2") or VERSION.startswith("8.3"):
 			branch_to_test = "5.X"
 			expected_output = "Welcome to CakePHP 5"
 

--- a/tests/test_cakephp.py
+++ b/tests/test_cakephp.py
@@ -23,30 +23,6 @@ class TestCakePHPAppExTemplate:
 	def teardown_method(self):
 		self.oc_api.delete_project()
 
-	def test_local_template_inside_cluster(self):
-		branch_to_test = "master"
-		expected_output = "Welcome to PHP"
-		if VERSION.startswith("7.4") or VERSION.startswith("8.0"):
-			branch_to_test = "4.X"
-			expected_output = "Welcome to CakePHP 4"
-		if VERSION.startswith("8.1") or VERSION.startswith("8.2"):
-			branch_to_test = "5.X"
-			expected_output = "Welcome to CakePHP 5"
-
-		template_json = "../openshift/templates/cakephp.json"
-		assert self.oc_api.deploy_template(
-			template=template_json, name_in_template="cakephp-example", expected_output=expected_output,
-			openshift_args=[
-				f"SOURCE_REPOSITORY_REF={branch_to_test}",
-				f"PHP_VERSION={VERSION}",
-				"NAME=cakephp-example"
-			]
-		)
-		assert self.oc_api.template_deployed(name_in_template="cakephp-example")
-		assert self.oc_api.check_response_inside_cluster(
-			name_in_template="cakephp-example", expected_output=expected_output
-		)
-
 	def test_remote_template_inside_cluster(self):
 		branch_to_test = "master"
 		expected_output = "Welcome to PHP"
@@ -64,30 +40,7 @@ class TestCakePHPAppExTemplate:
 			template=template_json, name_in_template="cakephp-example", expected_output=expected_output,
 			openshift_args=[f"SOURCE_REPOSITORY_REF={branch_to_test}", f"PHP_VERSION={VERSION}", "NAME=cakephp-example"]
 		)
-		assert self.oc_api.template_deployed(name_in_template="cakephp-example")
+		assert self.oc_api.is_template_deployed(name_in_template="cakephp-example")
 		assert self.oc_api.check_response_inside_cluster(
-			name_in_template="cakephp-example", expected_output=expected_output
-		)
-
-	def test_remote_template_by_request(self):
-		branch_to_test = "master"
-		expected_output = "Welcome to PHP"
-		if VERSION.startswith("7.4") or VERSION.startswith("8.0"):
-			branch_to_test = "4.X"
-			expected_output = "Welcome to CakePHP 4"
-		elif VERSION.startswith("8.1") or VERSION.startswith("8.2"):
-			branch_to_test = "5.X"
-			expected_output = "Welcome to CakePHP 5"
-
-		template_json = self.oc_api.get_raw_url_for_json(
-			container="cakephp-ex", branch=branch_to_test, dir="openshift/templates", filename="cakephp.json"
-		)
-		assert self.oc_api.deploy_template(
-			template=template_json, name_in_template="cakephp-example", expected_output=expected_output,
-			openshift_args=[f"SOURCE_REPOSITORY_REF={branch_to_test}", f"PHP_VERSION={VERSION}", "NAME=cakephp-example"]
-		)
-		assert self.oc_api.template_deployed(name_in_template="cakephp-example")
-		assert self.oc_api.check_response_outside_cluster(
-			protocol="https",
 			name_in_template="cakephp-example", expected_output=expected_output
 		)

--- a/tests/test_cakephp_mysql.py
+++ b/tests/test_cakephp_mysql.py
@@ -18,11 +18,11 @@ class TestCakePHPAppMySQLExTemplate:
 		self.oc_api = OpenShiftAPI(pod_name_prefix="cakephp-example")
 		json_raw_file = self.oc_api.get_raw_url_for_json(container="s2i-php-container", dir="imagestreams",
 														 filename="php-rhel.json")
-		self.oc_api.import_is(path=json_raw_file, name="php")
+		self.oc_api.import_is(path=json_raw_file, name="php", skip_check=True)
 		json_raw_file = self.oc_api.get_raw_url_for_json(
 			container="mysql-container", dir="imagestreams", filename="mysql-rhel.json"
 		)
-		self.oc_api.import_is(path=json_raw_file, name="mysql")
+		self.oc_api.import_is(path=json_raw_file, name="mysql", skip_check=True)
 
 	def teardown_method(self):
 		self.oc_api.delete_project()
@@ -32,10 +32,10 @@ class TestCakePHPAppMySQLExTemplate:
 		expected_output = "Welcome to PHP"
 		if VERSION.startswith("7.4") or VERSION.startswith("8.0"):
 			branch_to_test = "4.X"
-			expected_output = "Welcome to CakePHP 4"
-		if VERSION.startswith("8.1") or VERSION.startswith("8.2"):
+			expected_output = "Welcome to CakePHP"
+		if VERSION.startswith("8.1") or VERSION.startswith("8.2") or VERSION.startswith("8.3"):
 			branch_to_test = "5.X"
-			expected_output = "Welcome to CakePHP 5"
+			expected_output = "Welcome to CakePHP"
 
 		template_json = self.oc_api.get_raw_url_for_json(
 			container="cakephp-ex", branch=branch_to_test, dir="openshift/templates", filename="cakephp-mysql-persistent.json"
@@ -46,7 +46,10 @@ class TestCakePHPAppMySQLExTemplate:
 				f"SOURCE_REPOSITORY_REF={branch_to_test}",
 				f"PHP_VERSION={VERSION}",
 				"NAME=cakephp-example",
-                "MYSQL_VERSION=8.0-el8"
+                "MYSQL_VERSION=8.0-el8",
+				"DATABASE_USER=testu",
+				"DATABASE_PASSWORD=testp",
+				"DATABASE_NAME=mysql"
 			]
 		)
 		assert self.oc_api.is_template_deployed(name_in_template="cakephp-example")

--- a/tests/test_cakephp_mysql.py
+++ b/tests/test_cakephp_mysql.py
@@ -27,30 +27,6 @@ class TestCakePHPAppMySQLExTemplate:
 	def teardown_method(self):
 		self.oc_api.delete_project()
 
-	def test_local_template_inside_cluster(self):
-		branch_to_test = "master"
-		expected_output = "Welcome to PHP"
-		if VERSION.startswith("7.4") or VERSION.startswith("8.0"):
-			branch_to_test = "4.X"
-			expected_output = "Welcome to CakePHP 4"
-		if VERSION.startswith("8.1") or VERSION.startswith("8.2"):
-			branch_to_test = "5.X"
-			expected_output = "Welcome to CakePHP 5"
-		template_json = "../openshift/templates/cakephp-mysql-persistent.json"
-		assert self.oc_api.deploy_template(
-			template=template_json, name_in_template="cakephp-example", expected_output=expected_output,
-			openshift_args=[
-				f"SOURCE_REPOSITORY_REF={branch_to_test}",
-				f"PHP_VERSION={VERSION}",
-				"NAME=cakephp-example",
-				"MYSQL_VERSION=8.0-el8"
-			]
-		)
-		assert self.oc_api.template_deployed(name_in_template="cakephp-example")
-		assert self.oc_api.check_response_inside_cluster(
-			name_in_template="cakephp-example", expected_output=expected_output
-		)
-
 	def test_remote_template_inside_cluster(self):
 		branch_to_test = "master"
 		expected_output = "Welcome to PHP"
@@ -73,35 +49,7 @@ class TestCakePHPAppMySQLExTemplate:
                 "MYSQL_VERSION=8.0-el8"
 			]
 		)
-		assert self.oc_api.template_deployed(name_in_template="cakephp-example")
+		assert self.oc_api.is_template_deployed(name_in_template="cakephp-example")
 		assert self.oc_api.check_response_inside_cluster(
-			name_in_template="cakephp-example", expected_output=expected_output
-		)
-
-	def test_remote_template_by_request(self):
-		branch_to_test = "master"
-		expected_output = "Welcome to PHP"
-		if VERSION.startswith("7.4") or VERSION.startswith("8.0"):
-			branch_to_test = "4.X"
-			expected_output = "Welcome to CakePHP 4"
-		elif VERSION.startswith("8.1") or VERSION.startswith("8.2"):
-			branch_to_test = "5.X"
-			expected_output = "Welcome to CakePHP 5"
-
-		template_json = self.oc_api.get_raw_url_for_json(
-			container="cakephp-ex", branch=branch_to_test, dir="openshift/templates", filename="cakephp-mysql-persistent.json"
-		)
-		assert self.oc_api.deploy_template(
-			template=template_json, name_in_template="cakephp-example", expected_output=expected_output,
-			openshift_args=[
-				f"SOURCE_REPOSITORY_REF={branch_to_test}",
-				f"PHP_VERSION={VERSION}",
-				"NAME=cakephp-example",
-                "MYSQL_VERSION=8.0-el8"
-			]
-		)
-		assert self.oc_api.template_deployed(name_in_template="cakephp-example")
-		assert self.oc_api.check_response_outside_cluster(
-			protocol="https",
 			name_in_template="cakephp-example", expected_output=expected_output
 		)


### PR DESCRIPTION
Fix test suite for testing PHP application
remove obsoleted functions that does not make sense. `test_local_template_inside_cluster` and
`test_remote_template_by_request`

