### PR TITLE
Add 'allow-plugins' section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
 		"sort-packages": true,
 		"platform": {
 			"php": "7.2"
+		},
+		"allow-plugins": {
+			"cakephp/plugin-installer": true
 		}
 	}
 }


### PR DESCRIPTION
Without this section, current latest composer 2.10.0 fails with

```
In PluginManager.php line 746:

  Your composer.lock was generated before the allow-plugins security feature
  was introduced and your composer.json does not define allow-plugins. Run "c
  omposer update --lock" locally and commit the updated composer.lock, then a
  dd an explicit allow-plugins section to composer.json. See https://getcompo
  ser.org/allow-plugins
```

Hit this in today's ubi8/php-74 refresh.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
