### PR TITLE
Let's fix PyTest suite for cakephp ex repository

### DIFF
--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -26,5 +26,5 @@ jobs:
           git_ref: "master"
           tmt_plan_regex: "rhel9-openshift-pytest"
           update_pull_request_status: true
-          pull_request_status_name: "RHEL9-OpenShift-4 - imagestream test ${{ matrix.version }}"
+          pull_request_status_name: "${{ matrix.os }}-OpenShift-4 - PyTest ${{ matrix.version }}"
           variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};OS=${{ matrix.os }};SINGLE_VERSION=${{ matrix.version }};TEST_NAME=test-openshift-pytest"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,15 @@
+TAGS = {
+    "rhel8": "-ubi8",
+    "rhel9": "-ubi9",
+    "rhel10": "-ubi10",
+}
+
+
+def is_test_allowed(os, version):
+    if os == "rhel8" and version in ["7.4", "8.2"]:
+        return True
+    if os == "rhel9" and version in ["8.0", "8.2", "8.3"]:
+        return True
+    if os == "rhel10" and version in ["8.3", "8.4"]:
+        return True
+    return False

--- a/tests/test_cakephp.py
+++ b/tests/test_cakephp.py
@@ -1,46 +1,70 @@
 import os
-
 import pytest
+
 from pathlib import Path
 
 from container_ci_suite.openshift import OpenShiftAPI
 
+from constants import TAGS, is_test_allowed
+
 test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 
 VERSION = os.getenv("SINGLE_VERSION")
-if not VERSION:
-	VERSION = "8.1-ubi8"
+OS = os.getenv("OS")
+PR_NUMBER = os.getenv("PR_NUMBER")
+
+TAG = TAGS.get(OS)
 
 
 class TestCakePHPAppExTemplate:
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="cakephp-example", shared_cluster=True)
+        json_raw_file = self.oc_api.get_raw_url_for_json(
+            container="s2i-php-container", dir="imagestreams", filename="php-rhel.json"
+        )
+        self.oc_api.import_is(path=json_raw_file, name="php", skip_check=True)
 
-	def setup_method(self):
-		self.oc_api = OpenShiftAPI(pod_name_prefix="cakephp-example")
-		json_raw_file = self.oc_api.get_raw_url_for_json(container="s2i-php-container", dir="imagestreams",
-														 filename="php-rhel.json")
-		self.oc_api.import_is(path=json_raw_file, name="php", skip_check=True)
+    def teardown_method(self):
+        self.oc_api.delete_project()
 
-	def teardown_method(self):
-		self.oc_api.delete_project()
+    def test_local_template_inside_cluster(self):
+        if not is_test_allowed(OS, VERSION):
+            pytest.skip(f"Local templates are not supported for {OS} and {VERSION}")
+        expected_output = "Welcome to CakePHP"
+        template_json = "../openshift/templates/cakephp.json"
+        assert self.oc_api.deploy_template(
+            template=template_json,
+            name_in_template="cakephp-example",
+            expected_output=expected_output,
+            openshift_args=[
+                f"SOURCE_REPOSITORY_REF=refs/pull/{PR_NUMBER}/head",
+                f"PHP_VERSION={VERSION}{TAG}",
+                "NAME=cakephp-example",
+            ],
+        )
+        assert self.oc_api.is_template_deployed(name_in_template="cakephp-example", timeout=600)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template="cakephp-example", expected_output=expected_output
+        )
 
-	def test_remote_template_inside_cluster(self):
-		branch_to_test = "master"
-		expected_output = "Welcome to PHP"
-		if VERSION.startswith("7.4") or VERSION.startswith("8.0"):
-			branch_to_test = "4.X"
-			expected_output = "Welcome to CakePHP 4"
-		if VERSION.startswith("8.1") or VERSION.startswith("8.2") or VERSION.startswith("8.3"):
-			branch_to_test = "5.X"
-			expected_output = "Welcome to CakePHP 5"
-
-		template_json = self.oc_api.get_raw_url_for_json(
-			container="cakephp-ex", branch=branch_to_test, dir="openshift/templates", filename="cakephp.json"
-		)
-		assert self.oc_api.deploy_template(
-			template=template_json, name_in_template="cakephp-example", expected_output=expected_output,
-			openshift_args=[f"SOURCE_REPOSITORY_REF={branch_to_test}", f"PHP_VERSION={VERSION}", "NAME=cakephp-example"]
-		)
-		assert self.oc_api.is_template_deployed(name_in_template="cakephp-example")
-		assert self.oc_api.check_response_inside_cluster(
-			name_in_template="cakephp-example", expected_output=expected_output
-		)
+    def test_remote_template_inside_cluster(self):
+        if not is_test_allowed(OS, VERSION):
+            pytest.skip(f"Remote templates are not supported for {OS} and {VERSION}")
+        expected_output = "Welcome to CakePHP"
+        template_json = self.oc_api.get_raw_url_for_json(
+            container="cakephp-ex", dir="openshift/templates", filename="cakephp.json"
+        )
+        assert self.oc_api.deploy_template(
+            template=template_json,
+            name_in_template="cakephp-example",
+            expected_output=expected_output,
+            openshift_args=[
+                f"SOURCE_REPOSITORY_REF=refs/pull/{PR_NUMBER}/head",
+                f"PHP_VERSION={VERSION}{TAG}",
+                "NAME=cakephp-example",
+            ],
+        )
+        assert self.oc_api.is_template_deployed(name_in_template="cakephp-example", timeout=600)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template="cakephp-example", expected_output=expected_output
+        )


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the test workflow labeling to use an OS-based naming scheme and align PyTest status names with the current test matrix.

* **Tests**
  * Improved OpenShift testing by gating execution to supported OS/version combinations.
  * Adjusted CakePHP template deployment tests to run in a shared cluster context, simplified template selection, and added a new local-template scenario.
  * Standardized expected output checks and increased deployment verification timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->