### PR TITLE
OKD-380: Add missing namespace to image trigger annotations

### DIFF
--- a/openshift/templates/cakephp-mysql-persistent.json
+++ b/openshift/templates/cakephp-mysql-persistent.json
@@ -374,7 +374,7 @@
         "annotations": {
           "description": "Defines how to deploy the database",
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {

--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -303,7 +303,7 @@
         "annotations": {
           "description": "Defines how to deploy the database",
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {


### PR DESCRIPTION
## Problem

Deploying CakePHP+MySQL from the OKD 4.22 Software Catalog fails with:

```
spec.containers[0].image: Invalid value: " ": must not have leading or trailing whitespace
```

Reported in https://github.com/okd-project/okd/issues/2337

## Root Cause

When templates were migrated from `DeploymentConfig` to `Deployment`, the `image.openshift.io/triggers` annotation on the MySQL database Deployment dropped the `namespace` field from the `ImageStreamTag` reference. Without it, the image trigger controller defaults to the Deployment's own namespace instead of `openshift`, so it can't find the ImageStream and the container image is never resolved.

## Fix

Add `"namespace":"${NAMESPACE}"` to the trigger annotation's `from` object on the database Deployment in both `cakephp-mysql` and `cakephp-mysql-persistent` templates. The `NAMESPACE` parameter already exists in both templates with a default value of `"openshift"`.

## Impact

These template files are the upstream source for `openshift/library` (via `make import`) and ultimately `openshift/cluster-samples-operator`. An immediate fix was applied directly to the operator in [openshift/cluster-samples-operator#701](https://github.com/openshift/cluster-samples-operator/pull/701). This upstream fix ensures the bug doesn't recur on the next sync.