### PR TITLE
OKD-380: Add missing namespace to image trigger annotations

### DIFF
--- a/openshift/templates/cakephp-mysql-persistent.json
+++ b/openshift/templates/cakephp-mysql-persistent.json
@@ -327,7 +327,7 @@
         "annotations": {
           "description": "Defines how to deploy the database",
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {

--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -310,7 +310,7 @@
         "annotations": {
           "description": "Defines how to deploy the database",
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {


### PR DESCRIPTION
Backport of https://github.com/sclorg/cakephp-ex/pull/169 to the `5.X` branch.

Add `"namespace":"${NAMESPACE}"` to the `image.openshift.io/triggers` annotation's `from` object on the database Deployment in both `cakephp-mysql` and `cakephp-mysql-persistent` templates. Without it, the image trigger controller looks for ImageStreams in the user's namespace instead of `openshift`, causing image resolution to fail.

Related: https://github.com/okd-project/okd/issues/2337